### PR TITLE
[Feature/custom-aggregate-root] AggregateRoot, EventPublisher 구현 

### DIFF
--- a/common/src/main/java/org/flab/deliveryplatform/common/domain/AggregateRoot.java
+++ b/common/src/main/java/org/flab/deliveryplatform/common/domain/AggregateRoot.java
@@ -3,6 +3,7 @@ package org.flab.deliveryplatform.common.domain;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class AggregateRoot {
 
@@ -13,7 +14,12 @@ public class AggregateRoot {
         return event;
     }
 
-    public Collection<Object> domainEvents() {
-        return domainEvents;
+    public Collection<Object> getOccurredEvents() {
+        List<Object> occurredEvents = domainEvents.stream()
+            .collect(Collectors.toUnmodifiableList());
+
+        domainEvents.clear();
+
+        return occurredEvents;
     }
 }

--- a/common/src/main/java/org/flab/deliveryplatform/common/domain/AggregateRoot.java
+++ b/common/src/main/java/org/flab/deliveryplatform/common/domain/AggregateRoot.java
@@ -1,0 +1,19 @@
+package org.flab.deliveryplatform.common.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class AggregateRoot {
+
+    private final transient List<Object> domainEvents = new ArrayList<>();
+
+    protected Object registerEvent(Object event) {
+        this.domainEvents.add(event);
+        return event;
+    }
+
+    public Collection<Object> domainEvents() {
+        return domainEvents;
+    }
+}

--- a/common/src/main/java/org/flab/deliveryplatform/common/event/Event.java
+++ b/common/src/main/java/org/flab/deliveryplatform/common/event/Event.java
@@ -1,0 +1,13 @@
+package org.flab.deliveryplatform.common.event;
+
+import lombok.Getter;
+
+@Getter
+public abstract class Event {
+
+    private long timestamp;
+
+    public Event() {
+        this.timestamp = System.currentTimeMillis();
+    }
+}

--- a/common/src/main/java/org/flab/deliveryplatform/common/event/Event.java
+++ b/common/src/main/java/org/flab/deliveryplatform/common/event/Event.java
@@ -1,13 +1,14 @@
 package org.flab.deliveryplatform.common.event;
 
+import java.time.Instant;
 import lombok.Getter;
 
 @Getter
 public abstract class Event {
 
-    private long timestamp;
+    private Instant occurredOn;
 
     public Event() {
-        this.timestamp = System.currentTimeMillis();
+        this.occurredOn = Instant.now();
     }
 }

--- a/common/src/main/java/org/flab/deliveryplatform/common/event/EventPublisher.java
+++ b/common/src/main/java/org/flab/deliveryplatform/common/event/EventPublisher.java
@@ -1,0 +1,8 @@
+package org.flab.deliveryplatform.common.event;
+
+import java.util.Collection;
+
+public interface EventPublisher {
+
+    void publish(Collection<Object> domainEvents);
+}

--- a/common/src/main/java/org/flab/deliveryplatform/common/event/EventPublisher.java
+++ b/common/src/main/java/org/flab/deliveryplatform/common/event/EventPublisher.java
@@ -4,5 +4,7 @@ import java.util.Collection;
 
 public interface EventPublisher {
 
-    void publish(Collection<Object> domainEvents);
+    void publish(Object domainEvent);
+
+    void publishAll(Collection<Object> domainEvents);
 }

--- a/common/src/test/java/org/flab/deliveryplatform/common/domain/AggregateRootTest.java
+++ b/common/src/test/java/org/flab/deliveryplatform/common/domain/AggregateRootTest.java
@@ -1,0 +1,41 @@
+package org.flab.deliveryplatform.common.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.flab.deliveryplatform.common.event.Event;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AggregateRootTest {
+
+    private AggregateRoot aggregateRoot;
+
+    @BeforeEach
+    void setUp() {
+        aggregateRoot = new AggregateRoot();
+    }
+
+    @Test
+    void getOccurredEvents() {
+        aggregateRoot.registerEvent(new FakeEvent(1L));
+        aggregateRoot.registerEvent(new FakeEvent(2L));
+
+        Collection<Object> occurredEvents = aggregateRoot.getOccurredEvents();
+
+        assertThat(occurredEvents).hasSize(2);
+        assertThatThrownBy(() -> occurredEvents.add(new FakeEvent(3L)))
+            .isInstanceOf(UnsupportedOperationException.class);
+
+        Collection<Object> emptyEvents = aggregateRoot.getOccurredEvents();
+        assertThat(emptyEvents).hasSize(0);
+    }
+
+    @RequiredArgsConstructor
+    static class FakeEvent extends Event {
+
+        private final Long id;
+    }
+}

--- a/delivery-api/delivery-application/build.gradle
+++ b/delivery-api/delivery-application/build.gradle
@@ -1,6 +1,7 @@
 version '1.0-SNAPSHOT'
 
 dependencies {
+    implementation project(':common')
     implementation project(':delivery-api:delivery-domain')
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/delivery-api/delivery-application/src/main/java/org/flab/deliveryplatform/delivery/application/service/CompleteDeliveryService.java
+++ b/delivery-api/delivery-application/src/main/java/org/flab/deliveryplatform/delivery/application/service/CompleteDeliveryService.java
@@ -1,6 +1,7 @@
 package org.flab.deliveryplatform.delivery.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.flab.deliveryplatform.common.event.EventPublisher;
 import org.flab.deliveryplatform.delivery.application.port.CompleteDeliveryUseCase;
 import org.flab.deliveryplatform.delivery.application.port.DeliveryRepository;
 import org.flab.deliveryplatform.delivery.application.port.exception.DeliveryNotFoundException;
@@ -14,6 +15,8 @@ public class CompleteDeliveryService implements CompleteDeliveryUseCase {
 
     private final DeliveryRepository deliveryRepository;
 
+    private final EventPublisher eventPublisher;
+
     @Transactional
     @Override
     public void completeDelivery(Long deliveryId) {
@@ -22,6 +25,6 @@ public class CompleteDeliveryService implements CompleteDeliveryUseCase {
 
         delivery.complete();
 
-        deliveryRepository.save(delivery);
+        eventPublisher.publish(delivery.domainEvents());
     }
 }

--- a/delivery-api/delivery-application/src/main/java/org/flab/deliveryplatform/delivery/application/service/CompleteDeliveryService.java
+++ b/delivery-api/delivery-application/src/main/java/org/flab/deliveryplatform/delivery/application/service/CompleteDeliveryService.java
@@ -25,6 +25,6 @@ public class CompleteDeliveryService implements CompleteDeliveryUseCase {
 
         delivery.complete();
 
-        eventPublisher.publish(delivery.domainEvents());
+        eventPublisher.publish(delivery.getOccurredEvents());
     }
 }

--- a/delivery-api/delivery-domain/src/main/java/org/flab/deliveryplatform/delivery/domain/Delivery.java
+++ b/delivery-api/delivery-domain/src/main/java/org/flab/deliveryplatform/delivery/domain/Delivery.java
@@ -11,12 +11,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.AbstractAggregateRoot;
+import org.flab.deliveryplatform.common.domain.AggregateRoot;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Delivery extends AbstractAggregateRoot<Delivery> {
+public class Delivery extends AggregateRoot {
 
     @Column(name = "delivery_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/delivery-api/delivery-domain/src/main/java/org/flab/deliveryplatform/delivery/domain/DeliveryCompletedEvent.java
+++ b/delivery-api/delivery-domain/src/main/java/org/flab/deliveryplatform/delivery/domain/DeliveryCompletedEvent.java
@@ -1,6 +1,8 @@
 package org.flab.deliveryplatform.delivery.domain;
 
-public class DeliveryCompletedEvent {
+import org.flab.deliveryplatform.common.event.Event;
+
+public class DeliveryCompletedEvent extends Event {
 
     private Long orderId;
 

--- a/delivery-api/delivery-infrastructure/build.gradle
+++ b/delivery-api/delivery-infrastructure/build.gradle
@@ -1,6 +1,7 @@
 version '1.0-SNAPSHOT'
 
 dependencies {
+    implementation project(':common')
     implementation project(':delivery-api:delivery-domain')
     implementation project(':delivery-api:delivery-application')
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/delivery-api/delivery-infrastructure/src/main/java/org/flab/deliveryplatform/delivery/infrastructure/persistence/DeliveryEventPublisher.java
+++ b/delivery-api/delivery-infrastructure/src/main/java/org/flab/deliveryplatform/delivery/infrastructure/persistence/DeliveryEventPublisher.java
@@ -1,0 +1,22 @@
+package org.flab.deliveryplatform.delivery.infrastructure.persistence;
+
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.flab.deliveryplatform.common.event.EventPublisher;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class DeliveryEventPublisher implements EventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(Collection<Object> domainEvents) {
+        domainEvents.stream()
+            .forEach(e -> applicationEventPublisher.publishEvent(e));
+
+        domainEvents.clear();
+    }
+}

--- a/delivery-api/delivery-infrastructure/src/main/java/org/flab/deliveryplatform/delivery/infrastructure/persistence/DeliveryEventPublisher.java
+++ b/delivery-api/delivery-infrastructure/src/main/java/org/flab/deliveryplatform/delivery/infrastructure/persistence/DeliveryEventPublisher.java
@@ -13,10 +13,13 @@ public class DeliveryEventPublisher implements EventPublisher {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
-    public void publish(Collection<Object> domainEvents) {
-        domainEvents.stream()
-            .forEach(e -> applicationEventPublisher.publishEvent(e));
+    public void publish(Object domainEvent) {
+        applicationEventPublisher.publishEvent(domainEvent);
+    }
 
-        domainEvents.clear();
+    @Override
+    public void publishAll(Collection<Object> domainEvents) {
+        domainEvents.stream()
+            .forEach(this::publish);
     }
 }


### PR DESCRIPTION
1. 기존 AbstractAggregateRoot 에서는 save() 함수를 실행해야만 Event가 발행되어 직접 AggregateRoot 구현
2. EventPublisher interface 를 통해 이벤트 발행 구현체를 외부에서 주입

머지 실수로 다시 PR 올립니다 ㅠ.ㅠ